### PR TITLE
Add compile to vectorize capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,5 +11,13 @@ cmake ..
 make -j 8
 ```
 
+# How to compile with vectorization enabled
+
+```
+cd <project_root>
+cmake -D CMAKE_CXX_FLAGS="-ftree-vectorize" -B build
+```
+
+
 # How to save profiling values
 Create folder data for profiling files

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,12 @@
 file (GLOB_RECURSE SRCS . *.cpp)
 
-add_definitions("-fopt-info-vec -O2 /Qvec-report:2")
+if (WIN32)
+    add_definitions("-fopt-info-vec /Qvec-report:2")
+endif (WIN32)
+
+if (UNIX)
+    add_definitions("-fopt-info-vec -O2")
+endif (UNIX)
 
 add_library(${PROJECT_NAME}
     ${SRCS}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,7 @@
 file (GLOB_RECURSE SRCS . *.cpp)
 
+add_definitions("-fopt-info-vec -O2")
+
 add_library(${PROJECT_NAME}
     ${SRCS}
 )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,6 @@
 file (GLOB_RECURSE SRCS . *.cpp)
 
-add_definitions("-fopt-info-vec -O2")
+add_definitions("-fopt-info-vec -O2 /Qvec-report:2")
 
 add_library(${PROJECT_NAME}
     ${SRCS}


### PR DESCRIPTION
This approach uses a global CMake flag to trigger compiler vectorization. We also add the option to print out the vectorizations done and set the global optimization level to 2 to avoid vectorization when not expected.

Pls test on Windows Machine as well. :v: 

During the making of this PR, I also tried to add a second CMake target that runs with different compiler flags (using `add_executable` and `target_compile_options`). This worked for basic flags like `-Werror`, it failed to produce two binaries with different compiler flags.

However, to achieve a setup where one-command measurements should be possible we probably wont get around further investigation of this issue (Maybe, I'm also overthinking this or have too little CMake experience).