### PR TITLE
Vectorized (Ignore Vector Dependencies)

### DIFF
--- a/src/QuerySix.cpp
+++ b/src/QuerySix.cpp
@@ -57,6 +57,7 @@ double QuerySix::execute(const table& tab){
 double QuerySix::op_agg_sum(const table& tab, std::vector<int>& bitmap){
   int sum = 0;
   int size = bitmap.size();
+#pragma GCC ivdep
   for (int i = 0; i < size; i++) {
     sum += bitmap[i]  * tab.l_extendedprice[i] * tab.l_discount[i];
   }
@@ -65,6 +66,7 @@ double QuerySix::op_agg_sum(const table& tab, std::vector<int>& bitmap){
 
 void QuerySix::op_shipdate_ge(const table& tab, std::vector<int>& bitmap){
   int size = bitmap.size();
+#pragma GCC ivdep
   for (int i = 0; i < size; i++) {
     bitmap[i] = bitmap[i] * (tab.l_shipdate[i] >= 757382400);
   }
@@ -72,6 +74,7 @@ void QuerySix::op_shipdate_ge(const table& tab, std::vector<int>& bitmap){
 
 void QuerySix::op_shipdate_s(const table& tab, std::vector<int>& bitmap){
   int size = bitmap.size();
+#pragma GCC ivdep
   for (int i = 0; i < size; i++) {
     bitmap[i] = bitmap[i] *  (tab.l_shipdate[i] < 788918400);
   }
@@ -79,6 +82,7 @@ void QuerySix::op_shipdate_s(const table& tab, std::vector<int>& bitmap){
 
 void QuerySix::op_quantity_s(const table& tab, std::vector<int>& bitmap){
   int size = bitmap.size();
+#pragma GCC ivdep
   for (int i = 0; i < size; i++) {
     bitmap[i] = bitmap[i] * (tab.l_quantity[i] < 2400);
   }
@@ -86,6 +90,7 @@ void QuerySix::op_quantity_s(const table& tab, std::vector<int>& bitmap){
 
 void QuerySix::op_discount_ge(const table& tab, std::vector<int>& bitmap){
   int size = bitmap.size();
+#pragma GCC ivdep
     for ( int i = 0; i < size ; i ++) {
       bitmap[i] = (tab.l_discount[i] >= 5);
     }
@@ -93,6 +98,7 @@ void QuerySix::op_discount_ge(const table& tab, std::vector<int>& bitmap){
 
 void QuerySix::op_discount_se(const table& tab, std::vector<int>& bitmap){
   int size = bitmap.size();
+#pragma GCC ivdep
   for (int i = 0; i < size; i++) {
     bitmap[i] = bitmap[i] * (tab.l_discount[i] <= 7);
   }


### PR DESCRIPTION
Added another directive to enable auto-vectorization that is perhibited because of aliasing. (If you have pointers to the same thing and put it in the SIMD register you might get wrong results.)

Build without vectorization
-- Configuring done
-- Generating done
-- Build files have been written to: /home/lukas/Projects/execution-models/build
[ 12%] Building CXX object src/CMakeFiles/Execution_Models.dir/QueryOne.cpp.o
[ 25%] Building CXX object src/CMakeFiles/Execution_Models.dir/QuerySix.cpp.o
[ 37%] Building CXX object src/CMakeFiles/Execution_Models.dir/Main.cpp.o
[ 50%] Building CXX object src/CMakeFiles/Execution_Models.dir/StopWatch.cpp.o
[ 62%] Building CXX object src/CMakeFiles/Execution_Models.dir/TableReader.cpp.o
[ 75%] Linking CXX static library libExecution_Models.a
[ 75%] Built target Execution_Models
[ 87%] Building CXX object src/CMakeFiles/Main.dir/Main.cpp.o
[100%] Linking CXX executable Main
[100%] Built target Main
reading csv: Execution Time: 77163818 ns
query one normal: Execution Time: 423374 ns
query one hyrbid: Execution Time: 243597 ns
query one executed: Execution Time: 240939 ns
query six normal: Execution Time: 35870 ns
query six hybrid: Execution Time: 48271 ns
query six executed: Execution Time: 26516 ns
mkdir: cannot create directory ‘build/non_vectorized’: No such file or directory
mv: cannot stat 'build/src/*.csv': No such file or directory
build with vectroization
-- Configuring done
-- Generating done
-- Build files have been written to: /home/lukas/Projects/execution-models/build
[ 12%] Building CXX object src/CMakeFiles/Execution_Models.dir/QueryOne.cpp.o
[ 25%] Building CXX object src/CMakeFiles/Execution_Models.dir/Main.cpp.o
[ 37%] Building CXX object src/CMakeFiles/Execution_Models.dir/TableReader.cpp.o
[ 50%] Building CXX object src/CMakeFiles/Execution_Models.dir/QuerySix.cpp.o
[ 62%] Building CXX object src/CMakeFiles/Execution_Models.dir/StopWatch.cpp.o
/home/lukas/Projects/execution-models/src/QueryOne.cpp:75:23: note: loop vectorized
/home/lukas/Projects/execution-models/src/QuerySix.cpp:94:20: note: loop vectorized
/usr/include/c++/8/bits/stl_algobase.h:753:13: note: loop vectorized
/home/lukas/Projects/execution-models/src/QueryOne.cpp:75:23: note: loop vectorized
/home/lukas/Projects/execution-models/src/QuerySix.cpp:38:16: note: loop vectorized
/home/lukas/Projects/execution-models/src/QuerySix.cpp:61:17: note: loop vectorized
/home/lukas/Projects/execution-models/src/QuerySix.cpp:86:17: note: loop vectorized
/home/lukas/Projects/execution-models/src/QuerySix.cpp:70:17: note: loop vectorized
/home/lukas/Projects/execution-models/src/QuerySix.cpp:78:17: note: loop vectorized
/home/lukas/Projects/execution-models/src/QuerySix.cpp:102:17: note: loop vectorized
/home/lukas/Projects/execution-models/src/QuerySix.cpp:94:20: note: loop vectorized
/usr/include/c++/8/bits/stl_algobase.h:753:13: note: loop vectorized
/home/lukas/Projects/execution-models/src/QuerySix.cpp:61:17: note: loop vectorized
/home/lukas/Projects/execution-models/src/QuerySix.cpp:70:17: note: loop vectorized
/home/lukas/Projects/execution-models/src/QuerySix.cpp:78:17: note: loop vectorized
/home/lukas/Projects/execution-models/src/QuerySix.cpp:86:17: note: loop vectorized
/home/lukas/Projects/execution-models/src/QuerySix.cpp:94:20: note: loop vectorized
/home/lukas/Projects/execution-models/src/QuerySix.cpp:102:17: note: loop vectorized
[ 75%] Linking CXX static library libExecution_Models.a
[ 75%] Built target Execution_Models
[ 87%] Building CXX object src/CMakeFiles/Main.dir/Main.cpp.o
[100%] Linking CXX executable Main
[100%] Built target Main
reading csv: Execution Time: 69133638 ns
query one normal: Execution Time: 476510 ns
query one hyrbid: Execution Time: 268146 ns
query one executed: Execution Time: 254437 ns
query six normal: Execution Time: 20883 ns
query six hybrid: Execution Time: 45648 ns
query six executed: Execution Time: 28150 ns
